### PR TITLE
[codex] Add multi-platform deployment automation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_BUILD_VERSION: "20"
+  NODE_BUILD_VERSION: "22"
 
 jobs:
   plan-pipeline:
@@ -249,6 +249,7 @@ jobs:
       - name: Build static export
         working-directory: GovOn/frontend
         env:
+          NEXT_PUBLIC_BASE_PATH: /AIOSS_GovOn
           NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
         run: npm run build

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -1,0 +1,232 @@
+name: Deploy Container to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["Docker Image Publish"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "GHCR image tag to deploy"
+        required: false
+        default: "latest"
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  packages: read
+
+concurrency:
+  group: deploy-cloud-run
+  cancel-in-progress: false
+
+env:
+  SERVICE_NAME: ${{ vars.GCP_SERVICE_NAME || 'govon-api' }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast3' }}
+  AR_REPOSITORY: ${{ vars.GCP_AR_REPOSITORY || 'govon-repo' }}
+
+jobs:
+  validate-config:
+    name: Validate Cloud Run Config
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.config.outputs.available }}
+      should_deploy: ${{ steps.config.outputs.should_deploy }}
+      image_tag: ${{ steps.config.outputs.image_tag }}
+    steps:
+      - name: Check event and secrets
+        id: config
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          SHOULD_DEPLOY=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHOULD_DEPLOY=true
+            IMAGE_TAG="${{ github.event.inputs.image_tag || 'latest' }}"
+          elif [ "${{ github.event.workflow_run.conclusion }}" = "success" ] && [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            SHOULD_DEPLOY=true
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="latest"
+          fi
+
+          if [ -n "$GCP_SA_KEY" ] && [ -n "${{ env.GCP_PROJECT_ID }}" ]; then
+            AVAILABLE=true
+          else
+            AVAILABLE=false
+          fi
+
+          {
+            echo "available=$AVAILABLE"
+            echo "should_deploy=$SHOULD_DEPLOY"
+            echo "image_tag=$IMAGE_TAG"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$SHOULD_DEPLOY" != "true" ]; then
+            echo "Cloud Run deploy skipped: Docker workflow did not complete successfully on main." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$AVAILABLE" != "true" ]; then
+            {
+              echo "### Cloud Run Deploy"
+              echo ""
+              echo "Deployment skipped because GCP credentials are not configured."
+              echo ""
+              echo "Required secrets: \`GCP_SA_KEY\`, \`GCP_PROJECT_ID\`."
+              echo "Optional repository variables: \`GCP_REGION\`, \`GCP_AR_REPOSITORY\`, \`GCP_SERVICE_NAME\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  deploy:
+    name: Deploy to Cloud Run
+    needs: validate-config
+    if: needs.validate-config.outputs.available == 'true' && needs.validate-config.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: demo-cloud-run
+      url: ${{ steps.deploy.outputs.url }}
+    outputs:
+      revision: ${{ steps.deploy.outputs.revision }}
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine image tags
+        id: image
+        run: |
+          TAG="${{ needs.validate-config.outputs.image_tag }}"
+          REPOSITORY_LOWER="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          GHCR_IMAGE="ghcr.io/${REPOSITORY_LOWER}:${TAG}"
+          GCP_IMAGE="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.AR_REPOSITORY }}/govon-api:${TAG}"
+
+          {
+            echo "tag=$TAG"
+            echo "ghcr_image=$GHCR_IMAGE"
+            echo "gcp_image=$GCP_IMAGE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Enable Google Cloud APIs
+        run: |
+          gcloud services enable run.googleapis.com \
+            artifactregistry.googleapis.com \
+            iam.googleapis.com \
+            cloudresourcemanager.googleapis.com \
+            serviceusage.googleapis.com \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --quiet
+
+      - name: Ensure Artifact Registry repository
+        run: |
+          if ! gcloud artifacts repositories describe "${{ env.AR_REPOSITORY }}" \
+            --location "${{ env.GCP_REGION }}" \
+            --project "${{ env.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
+            gcloud artifacts repositories create "${{ env.AR_REPOSITORY }}" \
+              --repository-format=docker \
+              --location "${{ env.GCP_REGION }}" \
+              --description="GovOn container images" \
+              --project "${{ env.GCP_PROJECT_ID }}" \
+              --quiet
+          fi
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${{ env.GCP_REGION }}-docker.pkg.dev" --quiet
+
+      - name: Mirror GHCR image to Artifact Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker pull "${{ steps.image.outputs.ghcr_image }}"
+          docker tag "${{ steps.image.outputs.ghcr_image }}" "${{ steps.image.outputs.gcp_image }}"
+          docker push "${{ steps.image.outputs.gcp_image }}"
+
+      - name: Deploy service
+        id: deploy
+        env:
+          GOVON_API_KEY: ${{ secrets.GOVON_API_KEY }}
+        run: |
+          RUNTIME_ENV_VARS="SERVING_PROFILE=container,SKIP_MODEL_LOAD=true"
+          if [ -n "$GOVON_API_KEY" ]; then
+            RUNTIME_ENV_VARS="${RUNTIME_ENV_VARS},API_KEY=${GOVON_API_KEY}"
+          fi
+
+          gcloud run deploy "${{ env.SERVICE_NAME }}" \
+            --image="${{ steps.image.outputs.gcp_image }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --platform=managed \
+            --port=8000 \
+            --memory=4Gi \
+            --cpu=2 \
+            --min-instances=0 \
+            --max-instances=3 \
+            --timeout=300 \
+            --concurrency=80 \
+            --set-env-vars="$RUNTIME_ENV_VARS" \
+            --allow-unauthenticated \
+            --quiet
+
+          URL="$(gcloud run services describe "${{ env.SERVICE_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --format='value(status.url)')"
+          REVISION="$(gcloud run revisions list \
+            --service="${{ env.SERVICE_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --format='value(REVISION)' \
+            --limit=1 2>/dev/null || echo "unknown")"
+
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+
+  health-check:
+    name: Health Check
+    needs: deploy
+    runs-on: ubuntu-latest
+    outputs:
+      healthy: ${{ steps.check.outputs.healthy }}
+    steps:
+      - name: Wait for service stabilization
+        run: sleep 30
+
+      - name: Check /health
+        id: check
+        run: |
+          URL="${{ needs.deploy.outputs.url }}"
+          HEALTHY=false
+          HTTP_CODE="000"
+
+          for _ in $(seq 1 10); do
+            HTTP_CODE="$(curl -sf -o /tmp/health.json -w "%{http_code}" "${URL}/health" 2>/dev/null || echo "000")"
+            if [ "$HTTP_CODE" = "200" ]; then
+              HEALTHY=true
+              break
+            fi
+            sleep 15
+          done
+
+          echo "healthy=$HEALTHY" >> "$GITHUB_OUTPUT"
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Cloud Run Health Check"
+            echo ""
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| URL | ${URL} |"
+            echo "| HTTP code | ${HTTP_CODE} |"
+            echo "| Healthy | ${HEALTHY} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HEALTHY" != "true" ]; then
+            exit 1
+          fi

--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -1,0 +1,177 @@
+name: Frontend PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "GovOn/frontend/**"
+      - ".github/workflows/frontend-preview.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: frontend-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  build:
+    name: Build Static Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: GovOn/frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: GovOn/frontend
+        run: npm ci
+
+      - name: Lint
+        working-directory: GovOn/frontend
+        run: npm run lint
+
+      - name: Build Vercel-compatible static export
+        working-directory: GovOn/frontend
+        run: npm run build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-preview-static
+          path: GovOn/frontend/out
+          if-no-files-found: error
+
+  vercel-preview:
+    name: Deploy Vercel Preview
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Check Vercel secrets
+        id: vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Frontend Preview"
+              echo ""
+              echo "Vercel preview deployment was skipped because one or more secrets are missing."
+              echo ""
+              echo "Required secrets: \`VERCEL_TOKEN\`, \`VERCEL_ORG_ID\`, \`VERCEL_PROJECT_ID\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Checkout repository
+        if: steps.vercel.outputs.available == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        if: steps.vercel.outputs.available == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: GovOn/frontend/package-lock.json
+
+      - name: Install dependencies
+        if: steps.vercel.outputs.available == 'true'
+        working-directory: GovOn/frontend
+        run: npm ci
+
+      - name: Pull Vercel project settings
+        if: steps.vercel.outputs.available == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: npx --yes vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN" --cwd GovOn/frontend
+
+      - name: Build preview
+        if: steps.vercel.outputs.available == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: npx --yes vercel@latest build --token "$VERCEL_TOKEN" --cwd GovOn/frontend
+
+      - name: Deploy preview
+        if: steps.vercel.outputs.available == 'true'
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npx --yes vercel@latest deploy --prebuilt --yes --token "$VERCEL_TOKEN" --cwd GovOn/frontend > vercel-deploy.log
+          cat vercel-deploy.log
+          URL="$(grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' vercel-deploy.log | tail -1)"
+          if [ -z "$URL" ]; then
+            echo "::error::Could not determine Vercel preview URL."
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Frontend Preview"
+            echo ""
+            echo "Preview URL: $URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment preview URL
+        if: steps.vercel.outputs.available == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- govon-frontend-preview -->';
+            const body = [
+              marker,
+              '### Frontend PR Preview',
+              '',
+              '| Item | Value |',
+              '|---|---|',
+              `| Preview URL | ${{ steps.deploy.outputs.url }} |`,
+              `| Commit | \`${context.sha.slice(0, 7)}\` |`,
+            ].join('\n');
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/monitor-cloud-run.yml
+++ b/.github/workflows/monitor-cloud-run.yml
@@ -1,0 +1,205 @@
+name: Cloud Run Monitoring
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: monitor-cloud-run
+  cancel-in-progress: true
+
+env:
+  SERVICE_NAME: ${{ vars.GCP_SERVICE_NAME || 'govon-api' }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast3' }}
+
+jobs:
+  monitor:
+    name: Monitor Cloud Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check GCP credentials
+        id: config
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ -n "$GCP_SA_KEY" ] && [ -n "${{ env.GCP_PROJECT_ID }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Cloud Run Monitoring"
+              echo ""
+              echo "Monitoring skipped because GCP credentials are not configured."
+              echo ""
+              echo "Required secrets: \`GCP_SA_KEY\`, \`GCP_PROJECT_ID\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.config.outputs.available == 'true'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        if: steps.config.outputs.available == 'true'
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Get service URL
+        id: service
+        if: steps.config.outputs.available == 'true'
+        continue-on-error: true
+        run: |
+          URL="$(gcloud run services describe "${{ env.SERVICE_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --format='value(status.url)' 2>/dev/null || echo "")"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Health check
+        id: health
+        if: steps.config.outputs.available == 'true'
+        continue-on-error: true
+        run: |
+          URL="${{ steps.service.outputs.url }}"
+          if [ -z "$URL" ]; then
+            {
+              echo "status=unknown"
+              echo "http_code=000"
+              echo "latency=0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          HTTP_CODE="$(curl -sf -o /tmp/health-response.json -w "%{http_code}" "${URL}/health" 2>/dev/null || echo "000")"
+          LATENCY="$(curl -sf -o /dev/null -w "%{time_total}" "${URL}/health" 2>/dev/null || echo "0")"
+
+          {
+            echo "http_code=$HTTP_CODE"
+            echo "latency=$LATENCY"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "status=healthy" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=unhealthy" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get revision
+        id: revision
+        if: steps.config.outputs.available == 'true'
+        continue-on-error: true
+        run: |
+          REVISION="$(gcloud run revisions list \
+            --service="${{ env.SERVICE_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --format='value(REVISION)' \
+            --limit=1 2>/dev/null || echo "unknown")"
+          echo "value=$REVISION" >> "$GITHUB_OUTPUT"
+
+      - name: Create alert issue on failure
+        if: steps.health.outputs.status == 'unhealthy'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            for (const label of [
+              { name: 'monitoring', color: '0366d6', description: 'Automated monitoring signal' },
+              { name: 'alert', color: 'd73a4a', description: 'Service health alert' },
+            ]) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+              }
+            }
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'monitoring,alert',
+              state: 'open',
+              per_page: 100,
+            });
+
+            if (existing.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Cloud Run service unhealthy: ${new Date().toISOString()}`,
+                labels: ['monitoring', 'alert'],
+                body: [
+                  '## Cloud Run Monitoring Alert',
+                  '',
+                  '| Item | Value |',
+                  '|---|---|',
+                  `| Service | ${{ env.SERVICE_NAME }} |`,
+                  `| URL | ${{ steps.service.outputs.url }} |`,
+                  `| HTTP code | ${{ steps.health.outputs.http_code }} |`,
+                  `| Revision | ${{ steps.revision.outputs.value }} |`,
+                  `| Detected at | ${new Date().toISOString()} |`,
+                  '',
+                  'The Cloud Run health check failed against `/health`.',
+                ].join('\n'),
+              });
+            }
+
+      - name: Close alert if recovered
+        if: steps.health.outputs.status == 'healthy'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'monitoring,alert',
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const issue of existing.data) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Cloud Run service recovered at ${new Date().toISOString()}.`,
+              });
+            }
+
+      - name: Monitoring summary
+        if: always()
+        run: |
+          if [ "${{ steps.config.outputs.available }}" = "true" ]; then
+            {
+              echo "### Cloud Run Monitoring"
+              echo ""
+              echo "| Metric | Value |"
+              echo "|---|---|"
+              echo "| Service | ${{ env.SERVICE_NAME }} |"
+              echo "| URL | ${{ steps.service.outputs.url }} |"
+              echo "| Status | ${{ steps.health.outputs.status }} |"
+              echo "| HTTP code | ${{ steps.health.outputs.http_code }} |"
+              echo "| Latency | ${{ steps.health.outputs.latency }}s |"
+              echo "| Revision | ${{ steps.revision.outputs.value }} |"
+              echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/GovOn/frontend/next.config.ts
+++ b/GovOn/frontend/next.config.ts
@@ -1,10 +1,15 @@
 import type { NextConfig } from "next";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 const nextConfig: NextConfig = {
-  output: 'export',
-  basePath: '/GovOn',
-  assetPrefix: '/GovOn/',
-  // Images optimization is not supported with static export, so we need to disable it
+  output: "export",
+  ...(basePath
+    ? {
+        basePath,
+        assetPrefix: `${basePath}/`,
+      }
+    : {}),
   images: {
     unoptimized: true,
   },

--- a/GovOn/frontend/package-lock.json
+++ b/GovOn/frontend/package-lock.json
@@ -1844,11 +1844,10 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -2544,11 +2543,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5386,9 +5384,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5403,11 +5401,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/GovOn/frontend/package.json
+++ b/GovOn/frontend/package.json
@@ -28,6 +28,11 @@
       "eslint --fix"
     ]
   },
+  "overrides": {
+    "next": {
+      "postcss": "8.5.10"
+    }
+  },
   "dependencies": {
     "next": "16.2.6",
     "react": "19.2.6",

--- a/docs/deployment-multi-platform.md
+++ b/docs/deployment-multi-platform.md
@@ -1,0 +1,118 @@
+# Multi-platform Deployment Automation
+
+This repository uses three deployment surfaces:
+
+- GitHub Pages for the static frontend production site.
+- Vercel for pull request preview deployments.
+- Google Cloud Run for the Dockerized API service.
+
+## Frontend Production: GitHub Pages
+
+Workflow: `.github/workflows/ci-cd.yml`
+
+The CI/CD workflow builds `GovOn/frontend` as a static Next.js export and deploys the `out` directory to GitHub Pages on pushes to `main`. The frontend build sets:
+
+- `NEXT_PUBLIC_BASE_PATH=/AIOSS_GovOn`
+- `NEXT_PUBLIC_SITE_URL` from repository secrets, when configured
+- `NEXT_PUBLIC_API_BASE_URL` from repository secrets, when configured
+
+The repository is currently expected to serve the frontend at:
+
+```text
+https://yuujjjj.github.io/AIOSS_GovOn/
+```
+
+## Pull Request Preview: Vercel
+
+Workflow: `.github/workflows/frontend-preview.yml`
+
+The preview workflow runs on pull requests to `main` when `GovOn/frontend` changes. It:
+
+1. Installs dependencies with Node.js 22.
+2. Runs frontend lint.
+3. Builds the static export without a GitHub Pages base path.
+4. Uploads the static build artifact.
+5. Deploys a Vercel preview if the Vercel secrets are configured.
+6. Writes the preview URL back to the pull request conversation.
+
+Required GitHub repository secrets:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+If these secrets are missing, the workflow still validates the frontend build and records that the preview deploy was skipped.
+
+## Docker Image Pipeline
+
+Workflow: `.github/workflows/docker-publish.yml`
+
+The Docker workflow builds `GovOn/Dockerfile`, pushes the image to GitHub Container Registry, pulls the pushed image back to the runner, and verifies local container execution through `GET /health`.
+
+Image format for this repository:
+
+```text
+ghcr.io/yuujjjj/aioss_govon:sha-<commit>
+ghcr.io/yuujjjj/aioss_govon:latest
+```
+
+The `latest` tag is published on successful pushes to `main`.
+
+## Container Deployment: Google Cloud Run
+
+Workflow: `.github/workflows/deploy-cloud-run.yml`
+
+The Cloud Run workflow starts after `Docker Image Publish` completes successfully on `main`, or manually through `workflow_dispatch`. It:
+
+1. Reads the GHCR image tag to deploy.
+2. Authenticates to Google Cloud.
+3. Enables required Google Cloud APIs.
+4. Creates the Artifact Registry Docker repository if it does not exist.
+5. Mirrors the GHCR image into Artifact Registry.
+6. Deploys the container to Cloud Run.
+7. Runs a post-deploy health check against `/health`.
+
+Required GitHub repository secrets:
+
+- `GCP_SA_KEY`
+- `GCP_PROJECT_ID`
+
+Optional GitHub repository variables:
+
+- `GCP_REGION`, default `asia-northeast3`
+- `GCP_AR_REPOSITORY`, default `govon-repo`
+- `GCP_SERVICE_NAME`, default `govon-api`
+
+Optional GitHub repository secret:
+
+- `GOVON_API_KEY`, passed to the service as `API_KEY` when configured
+
+The service account in `GCP_SA_KEY` should have enough permission to deploy Cloud Run services, push Artifact Registry images, use the runtime service account, and enable required APIs.
+
+## Health Monitoring
+
+Workflow: `.github/workflows/monitor-cloud-run.yml`
+
+The monitoring workflow runs every 10 minutes and can also be started manually. It:
+
+1. Resolves the Cloud Run service URL.
+2. Calls `/health`.
+3. Records HTTP status, latency, revision, and timestamp in the workflow summary.
+4. Opens a GitHub issue labeled `monitoring` and `alert` when the service is unhealthy.
+5. Closes the open alert issue when the service recovers.
+
+The monitoring workflow uses the same `GCP_SA_KEY`, `GCP_PROJECT_ID`, `GCP_REGION`, and `GCP_SERVICE_NAME` settings as the deploy workflow.
+
+## Operational Checklist
+
+Before this automation is fully active:
+
+1. Commit and push these workflow changes to GitHub.
+2. Configure Vercel secrets if PR preview URLs are required.
+3. Configure GCP secrets and variables if Cloud Run deployment is required.
+4. Ensure GitHub Pages is enabled with the GitHub Actions source.
+5. Push or merge to `main` and confirm:
+   - `CI/CD` deploys the Pages artifact.
+   - `Docker Image Publish` publishes and smoke-tests the GHCR image.
+   - `Deploy Container to Cloud Run` deploys the image and passes `/health`.
+   - `Cloud Run Monitoring` writes a healthy summary or opens an alert issue.


### PR DESCRIPTION
## Summary

- Add Vercel-based frontend PR preview workflow with build artifact upload and PR preview URL comments.
- Add Cloud Run deployment and monitoring workflows for the Docker image published to GHCR.
- Fix GitHub Pages static export base path for `https://yuujjjj.github.io/AIOSS_GovOn/` and move frontend CI to Node 22.
- Add frontend dependency overrides/lockfile updates so `npm audit` reports zero vulnerabilities.
- Document the multi-platform deployment strategy and required repository secrets/variables.

## Validation

- `actionlint .github/workflows/ci-cd.yml .github/workflows/frontend-preview.yml .github/workflows/deploy-cloud-run.yml .github/workflows/monitor-cloud-run.yml`
- `git diff --check`
- `npx -y node@22 /usr/local/bin/npm ci`
- `npx -y node@22 /usr/local/bin/npm audit --json` -> 0 vulnerabilities
- `npx -y node@22 node_modules/eslint/bin/eslint.js .`
- `NEXT_PUBLIC_BASE_PATH=/AIOSS_GovOn npx -y node@22 node_modules/next/dist/bin/next build`
- Verified exported HTML no longer references `/GovOn/_next` asset URLs.

## Remaining manual configuration

- Add Vercel secrets if PR preview deployment should run: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
- Add GCP secrets for Cloud Run deployment: `GCP_SA_KEY`, `GCP_PROJECT_ID`.
- Optional GCP repository variables: `GCP_REGION`, `GCP_AR_REPOSITORY`, `GCP_SERVICE_NAME`.

GitHub Pages has been switched to `build_type: workflow` via the GitHub API.
