### PR TITLE
[codex] Fix Docker dependency resolution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,9 +79,13 @@ updates:
       - dependency-name: "torch"
         update-types:
           - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       - dependency-name: "vllm"
         update-types:
           - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       - dependency-name: "transformers"
         update-types:
           - "version-update:semver-major"

--- a/GovOn/requirements.txt
+++ b/GovOn/requirements.txt
@@ -1,5 +1,5 @@
 # Core ML/DL
-torch>=2.12.0
+torch==2.11.0
 transformers>=4.57.6
 accelerate>=1.0.0
 datasets>=4.8.5
@@ -14,7 +14,7 @@ peft>=0.16.0
 trl>=1.5.1
 
 # Inference & Serving
-vllm>=0.21.0
+vllm==0.22.0
 fastapi>=0.100.0
 uvicorn>=0.48.0
 pydantic>=2.0.0


### PR DESCRIPTION
## Summary
- Pin `torch` to `2.11.0` so it matches the `vllm==0.22.0` runtime requirement.
- Pin `vllm` to `0.22.0` to keep Docker builds reproducible.
- Prevent Dependabot from auto-opening torch/vllm version bumps that can recreate the resolver conflict.

## Root cause
The latest Docker publish run failed because `requirements.txt` required `torch>=2.12.0`, while the available `vllm` versions selected by the resolver require `torch==2.11.0`.

## Validation
- Checked `vllm==0.22.0` wheel metadata and confirmed it requires `torch==2.11.0`.
- Added repository-side guardrails in Dependabot config.

A Docker publish workflow dispatch will be run against this branch for full container build/push/smoke validation.
