### PR TITLE
[codex] Fix Vercel alias parsing for health check

### DIFF
--- a/.github/workflows/deploy-vercel-serverless.yml
+++ b/.github/workflows/deploy-vercel-serverless.yml
@@ -97,7 +97,7 @@ jobs:
           npx --yes vercel@latest deploy --prebuilt --prod --yes --token "$VERCEL_TOKEN" --cwd GovOn/frontend > vercel-deploy.log
           cat vercel-deploy.log
           DEPLOYMENT_URL="$(grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' vercel-deploy.log | tail -1)"
-          ALIAS_URL="$(sed -nE 's/.*Aliased[[:space:]]+(https:\/\/[^[:space:]]+\.vercel\.app[^[:space:]]*).*/\1/p' vercel-deploy.log | tail -1)"
+          ALIAS_URL="$(grep 'Aliased' vercel-deploy.log | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | tail -1)"
           URL="${ALIAS_URL:-$DEPLOYMENT_URL}"
           if [ -z "$URL" ]; then
             echo "::error::Could not determine Vercel deployment URL."


### PR DESCRIPTION
## Summary

- Parse the public Vercel production alias from the `Aliased` log line by grepping the URL from that line.
- Keep falling back to the immutable deployment URL if no alias is present.

## Root Cause

The previous `sed` pattern did not survive the ANSI/control characters in the Vercel deploy output, so the workflow still selected the protected immutable deployment URL and the post-deploy health check failed.

## Validation

- Replayed a Vercel deploy log sample with ANSI control characters and confirmed the parser chooses `https://govon-frontend.vercel.app`.
- Live production health endpoint currently returns HTTP 200: `https://govon-frontend.vercel.app/api/health`.
