### PR TITLE
[codex] Use production Vercel URL for health check

### DIFF
--- a/.github/workflows/deploy-vercel-serverless.yml
+++ b/.github/workflows/deploy-vercel-serverless.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  VERCEL_PRODUCTION_URL: ${{ vars.VERCEL_PRODUCTION_URL || 'https://govon-frontend.vercel.app' }}
 
 jobs:
   deploy:
@@ -96,9 +97,9 @@ jobs:
         run: |
           npx --yes vercel@latest deploy --prebuilt --prod --yes --token "$VERCEL_TOKEN" --cwd GovOn/frontend > vercel-deploy.log
           cat vercel-deploy.log
-          DEPLOYMENT_URL="$(grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' vercel-deploy.log | tail -1)"
-          ALIAS_URL="$(grep 'Aliased' vercel-deploy.log | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | tail -1)"
-          URL="${ALIAS_URL:-$DEPLOYMENT_URL}"
+          DEPLOYMENT_URL="$(grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' vercel-deploy.log | tail -1 || true)"
+          URL="${{ env.VERCEL_PRODUCTION_URL }}"
+          URL="${URL%/}"
           if [ -z "$URL" ]; then
             echo "::error::Could not determine Vercel deployment URL."
             exit 1
@@ -129,7 +130,7 @@ jobs:
           HTTP_CODE="000"
 
           for _ in $(seq 1 10); do
-            HTTP_CODE="$(curl -sf -o /tmp/vercel-health.json -w "%{http_code}" "${HEALTH_URL}" 2>/dev/null || echo "000")"
+            HTTP_CODE="$(curl --max-time 15 -sf -o /tmp/vercel-health.json -w "%{http_code}" "${HEALTH_URL}" 2>/dev/null || echo "000")"
             if [ "$HTTP_CODE" = "200" ]; then
               HEALTHY=true
               break
@@ -148,5 +149,6 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$HEALTHY" != "true" ]; then
+            cat /tmp/vercel-health.json 2>/dev/null || true
             exit 1
           fi

--- a/docs/deployment-multi-platform.md
+++ b/docs/deployment-multi-platform.md
@@ -98,6 +98,10 @@ Required GitHub repository secrets:
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
 
+Optional GitHub repository variable:
+
+- `VERCEL_PRODUCTION_URL`, default `https://govon-frontend.vercel.app`
+
 ## Health Monitoring
 
 Workflow: `.github/workflows/monitor-vercel-serverless.yml`
@@ -153,5 +157,6 @@ The repository owner must configure external platform settings:
 
 - GitHub Pages source must be set to GitHub Actions.
 - Vercel secrets must be configured: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+- `VERCEL_PRODUCTION_URL` should be set if the production frontend domain is not `govon-frontend.vercel.app`.
 - `VERCEL_HEALTH_URL` should be set if the production domain is not `govon-frontend.vercel.app`.
 - If reviewers need unauthenticated preview access, Vercel deployment protection must be disabled for preview deployments.


### PR DESCRIPTION
## Summary
- use the configured production Vercel alias for the serverless deploy environment URL and health check
- keep the immutable Vercel deployment URL in the workflow summary for traceability
- document the optional VERCEL_PRODUCTION_URL repository variable

## Validation
- parsed deploy-vercel-serverless.yml as YAML
- verified https://govon-frontend.vercel.app/api/health returns HTTP 200